### PR TITLE
Remove passing tests from FAIL_LIST

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -14,8 +14,6 @@ FAIL_LIST += $(TESTS_DIR)/random_cached_shared/          # triggers Jira issue P
 FAIL_LIST += $(TESTS_DIR)/read_two_writes_back_to_back/  # triggers Jira issue PROJ-147
 FAIL_LIST += $(TESTS_DIR)/snoop_non-cached_collision/    # triggers Jira issue PROJ-149
 FAIL_LIST += $(TESTS_DIR)/amo_snoop_single_collision/    # triggers Jira issue PROJ-150
-FAIL_LIST += $(TESTS_DIR)/amo_read_write_collision/      # triggers Jira issue PROJ-153
-FAIL_LIST += $(TESTS_DIR)/amo_read_cached/               # triggers Jira issue PROJ-153
 
 
 PASS_LIST = $(filter-out $(FAIL_LIST), $(TESTLIST))


### PR DESCRIPTION
These tests now pass and are removed from FAIL_LIST:

 - amo_read_cached

 - amo_read_write_collision