### PR TITLE
Proj 163 update amo driver and monitor

### DIFF
--- a/tests/unit/tb/culsans_tb.sv
+++ b/tests/unit/tb/culsans_tb.sv
@@ -821,7 +821,7 @@ module culsans_tb
                             end
                             "random_non-shared" : begin
                                 test_header(testname, "Writes and reads to random non-shareable addresses, excluding AMO requests");
-                                base_addr = ArianeCfg.ExecuteRegionAddrBase[0];
+                                base_addr = ArianeCfg.ExecuteRegionAddrBase[2];
                             end
                         endcase
 
@@ -871,7 +871,7 @@ module culsans_tb
                             end
                             "random_non-shared_amo" : begin
                                 test_header(testname, "Writes and reads to random non-shareable addresses, including AMO requests");
-                                base_addr = ArianeCfg.ExecuteRegionAddrBase[0];
+                                base_addr = ArianeCfg.ExecuteRegionAddrBase[2];
                             end
                         endcase
 
@@ -895,7 +895,7 @@ module culsans_tb
                                             case (testname)
                                                 "random_cached_amo"     : offset = $urandom_range(ArianeCfg.CachedRegionLength[0]);
                                                 "random_shared_amo"     : offset = $urandom_range(ArianeCfg.CachedRegionAddrBase[0] - ArianeCfg.SharedRegionAddrBase[0]); // don't enter the cached region
-                                                "random_non-shared_amo" : offset = $urandom_range(ArianeCfg.ExecuteRegionLength[0]);
+                                                "random_non-shared_amo" : offset = $urandom_range(ArianeCfg.ExecuteRegionLength[2]);
                                             endcase
                                             if (port == 2) begin
                                                 dcache_drv[cc][2].wr(.addr(base_addr + offset), .data(64'hBEEFCAFE00000000 + offset));
@@ -1021,7 +1021,7 @@ module culsans_tb
 
                                         case (addr_region)
                                             0       : base_addr = ArianeCfg.CachedRegionAddrBase[0];
-                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[0];
+                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[2];
 
                                         endcase
 
@@ -1063,7 +1063,7 @@ module culsans_tb
 
                                         case (addr_region)
                                             0       : base_addr = ArianeCfg.SharedRegionAddrBase[0];
-                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[0];
+                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[2];
 
                                         endcase
 
@@ -1105,7 +1105,7 @@ module culsans_tb
                                         case (addr_region)
                                             0       : base_addr = ArianeCfg.CachedRegionAddrBase[0];
                                             1       : base_addr = ArianeCfg.SharedRegionAddrBase[0];
-                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[0];
+                                            default : base_addr = ArianeCfg.ExecuteRegionAddrBase[2];
 
                                         endcase
 

--- a/tests/unit/testlist/amo_upper_cache_line/Makefile
+++ b/tests/unit/testlist/amo_upper_cache_line/Makefile
@@ -1,0 +1,3 @@
+ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+TESTNAME := $(notdir $(patsubst %/,%,$(ROOT_DIR)))
+include ../../test_automation/Makefile

--- a/tests/unit/testlist/amo_upper_cache_line/sim.tcl
+++ b/tests/unit/testlist/amo_upper_cache_line/sim.tcl
@@ -1,0 +1,1 @@
+../../test_automation/sim.tcl

--- a/tests/unit/testlist/amo_upper_cache_line/wave.do
+++ b/tests/unit/testlist/amo_upper_cache_line/wave.do
@@ -1,0 +1,1 @@
+../../test_automation/wave.do


### PR DESCRIPTION
Improve AMO driver and monitor.
Add directed test amo_upper_cache_line to trigger a bug in PROJ-151.
Avoid AMO requests to some non-shared regions (see issue PROJ-165).